### PR TITLE
Rename references to main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - build-deployment
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
     <a href="https://circleci.com/gh/aaroncawte/bbncreative-portfolio" target="blank" rel="noopener noreferrer">
-        <img src="https://circleci.com/gh/aaroncawte/bbncreative-portfolio/tree/master.svg?style=svg&circle-token=dbf29770a59f46187030dc984ae4c03e1f988f42" alt="CircleCI" />
+        <img src="https://circleci.com/gh/aaroncawte/bbncreative-portfolio/tree/main.svg?style=svg&circle-token=dbf29770a59f46187030dc984ae4c03e1f988f42" alt="CircleCI" />
     </a>
 </p>
 


### PR DESCRIPTION
Name the project's default branch `main` instead of `master`, to stop perpetuating language that derives from slavery in my work.